### PR TITLE
fix: remove unused user variable

### DIFF
--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -24,7 +24,7 @@ import {
 } from 'react-icons/fa';
 
 const HeroSection: React.FC = () => {
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated } = useAuth();
   const [swiper, setSwiper] = useState<SwiperType | null>(null);
   const [isUserInteracting, setIsUserInteracting] = useState(false);
 


### PR DESCRIPTION
## Summary
- remove unused `user` variable from `HeroSection`

## Testing
- `pnpm lint` *(fails: unexpected any, unused vars, etc. unrelated to this change)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b92aff9044833180d18c56481f7116