### PR TITLE
Show proper notification for achievement unlock

### DIFF
--- a/src/i18n/locales/en/pages/messages.ts
+++ b/src/i18n/locales/en/pages/messages.ts
@@ -97,6 +97,7 @@ export const messagesPage = {
       },
       noMessage: 'No messages yet',
       avatarAlt: 'User avatar',
+      medalAlt: 'Medal image',
       openSidebar: 'Open channel list',
       selectPromptTitle: 'Select a channel to start chatting',
       selectPromptDescription: 'Choose a channel or private chat from the left to begin.',
@@ -129,6 +130,7 @@ export const messagesPage = {
         groupMessage: 'New group message: {{title}}',
         systemMessage: 'New system message: {{title}}',
         announcementMessage: 'New announcement: {{title}}',
+        achievementUnlocked: 'New achievement unlocked: {{title}}',
       },
       contents: {
         teamApplication: '{{userName}} applied to join your team',
@@ -149,6 +151,7 @@ export const messagesPage = {
         groupChannel: 'Group channel: {{title}}',
         systemChannel: 'System channel: {{title}}',
         announcementChannel: 'Announcement channel: {{title}}',
+        achievement: '{{description}}',
         genericFrom: 'From {{source}}',
       },
       fallbacks: {
@@ -170,6 +173,8 @@ export const messagesPage = {
         systemMessage: 'System message',
         announcement: 'Announcement channel',
         announcementMessage: 'Announcement message',
+        achievement: 'New achievement unlocked',
+        achievementDescription: 'You\'ve got a new achievement',
         unknownSource: 'Unknown source',
       },
     },

--- a/src/i18n/locales/zh/pages/messages.ts
+++ b/src/i18n/locales/zh/pages/messages.ts
@@ -97,6 +97,7 @@ export const messagesPage = {
       },
       noMessage: '暂无消息',
       avatarAlt: '用户头像',
+      medalAlt: '奖章图像',
       openSidebar: '打开频道列表',
       selectPromptTitle: '选择一个频道开始聊天',
       selectPromptDescription: '从左侧选择一个频道或私聊开始对话',
@@ -129,6 +130,7 @@ export const messagesPage = {
         groupMessage: '新群组消息：{{title}}',
         systemMessage: '新系统消息：{{title}}',
         announcementMessage: '新公告：{{title}}',
+        achievementUnlocked: '新成就解锁：{{title}}',
       },
       contents: {
         teamApplication: '{{userName}} 申请加入您的团队',
@@ -149,6 +151,7 @@ export const messagesPage = {
         groupChannel: '群组频道：{{title}}',
         systemChannel: '系统频道：{{title}}',
         announcementChannel: '公告频道：{{title}}',
+        achievement: '{{description}}',
         genericFrom: '来自 {{source}}',
       },
       fallbacks: {
@@ -170,6 +173,8 @@ export const messagesPage = {
         systemMessage: '系统消息',
         announcement: '公告频道',
         announcementMessage: '公告消息',
+        achievement: '新成就解锁',
+        achievementDescription: '获得了神秘的新成就',
         unknownSource: '未知来源',
       },
     },

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -2017,7 +2017,7 @@ const MessagesPage: React.FC = () => {
                                     ? 'bg-blue-500/20' 
                                     : notification.name.includes('user_achievement_unlock')
                                     ? 'bg-yellow-500/20'
-                                    :'bg-gray-500/20'
+                                    : 'bg-gray-500/20'
                                 }`}>
                                   {notification.name.includes('team_application') && (
                                     <FiUserPlus className="text-orange-500" size={20} />

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -8,7 +8,8 @@ import {
   FiCheck,
   FiUserPlus,
   FiPlus,
-  FiRefreshCw
+  FiRefreshCw,
+  FiAward
 } from 'react-icons/fi';
 import { useAuth } from '../hooks/useAuth';
 // 使用全局通知上下文，避免与 Navbar 各自实例不同步
@@ -1566,6 +1567,10 @@ const MessagesPage: React.FC = () => {
         return t('messages.notificationsPanel.titles.announcementMessage', {
           title: resolveTitle(notification.details?.title, 'announcement'),
         });
+      case 'user_achievement_unlock':
+        return t('messages.notificationsPanel.titles.achievementUnlocked', {
+          title: resolveTitle(notification.details?.title, 'achievement'),
+        });
       default:
         return notification.name;
     }
@@ -1671,6 +1676,10 @@ const MessagesPage: React.FC = () => {
       case 'channel_announce':
         return t('messages.notificationsPanel.contents.announcementChannel', {
           title: resolveTitle(notification.details?.title, 'announcementMessage'),
+        });
+      case 'user_achievement_unlock':
+        return t('messages.notificationsPanel.contents.achievement', {
+          description: resolveTitle(notification.details?.description, 'achievementDescription'),
         });
       default:
         return JSON.stringify(notification.details);
@@ -1985,6 +1994,18 @@ const MessagesPage: React.FC = () => {
                                     }}
                                   />
                                 ) : null}
+
+                                {notification.name.includes('user_achievement_unlock') && (
+                                  <img
+                                    src={String(notification.details?.cover_url)}
+                                    alt={t('messages.sidebar.medalAlt')}
+                                    className="w-10 h-10 object-cover"
+                                    onError={(e) => {
+                                      e.currentTarget.style.display = 'none';
+                                      e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                                    }}
+                                  />
+                                )}
                                 
                                 {/* 默认图标 - 在没有用户信息或头像加载失败时显示 */}
                                 <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
@@ -1994,13 +2015,18 @@ const MessagesPage: React.FC = () => {
                                     ? 'bg-orange-500/20' 
                                     : notification.name.includes('channel') 
                                     ? 'bg-blue-500/20' 
-                                    : 'bg-gray-500/20'
+                                    : notification.name.includes('user_achievement_unlock')
+                                    ? 'bg-yellow-500/20'
+                                    :'bg-gray-500/20'
                                 }`}>
                                   {notification.name.includes('team_application') && (
                                     <FiUserPlus className="text-orange-500" size={20} />
                                   )}
                                   {notification.name.includes('channel') && (
                                     <FiMessageCircle className="text-blue-500" size={20} />
+                                  )}
+                                  {notification.name.includes('user_achievement_unlock') && (
+                                    <FiAward className="text-yellow-500" size={20} />
                                   )}
                                   {!notification.name.includes('team_application') && !notification.name.includes('channel') && (
                                     <FiBell className="text-gray-500" size={20} />


### PR DESCRIPTION
This PR added notification handling support for achievement unlock messages:

- The medal image is shown at the left side, if possible
- The description of the achievement is shown as the notification's content
