### PR TITLE
fix(bbcode): adjustments to BBCode parsers

### DIFF
--- a/src/i18n/locales/en/pages/profile.ts
+++ b/src/i18n/locales/en/pages/profile.ts
@@ -253,7 +253,7 @@ export const profilePage = {
         missingColor: 'Missing color',
         invalidColor: 'Invalid color format',
         missingSize: 'Missing font size',
-        invalidSize: 'Invalid or unsupported font size',
+        invalidSize: 'Invalid font size (should be within 30-200)',
         missingQuotes: 'The author should be wrapped in double quotes',
         missingUrl: 'Missing target URL',
         invalidUrl: 'Unsupported URL',

--- a/src/i18n/locales/zh/pages/profile.ts
+++ b/src/i18n/locales/zh/pages/profile.ts
@@ -252,7 +252,7 @@ export const profilePage = {
         missingColor: '需要指定颜色',
         invalidColor: '颜色格式无效',
         missingSize: '需要指定字体大小',
-        invalidSize: '字体大小无效或不支持',
+        invalidSize: '字体大小无效（范围为 30~200）',
         missingQuotes: '引用作者应使用双引号包围',
         missingUrl: '需要目标 URL',
         invalidUrl: '不支持的 URL',

--- a/src/utils/bbcodeParser.ts
+++ b/src/utils/bbcodeParser.ts
@@ -363,7 +363,7 @@ export class BBCodeParser {
       validator: (_param?: string, content?: string) => {
         if (!content) return new TagValidationResult(false, et('missingUrl'));
         return new TagValidationResult(
-          /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i.test(content),
+          /^https?:\/\/.+$/i.test(content),
           et('invalidImageUrl')
         );
       },
@@ -402,7 +402,7 @@ export class BBCodeParser {
       validator: (_param?: string, content?: string) => {
         if (!content) return new TagValidationResult(false, et('missingUrl'));
         return new TagValidationResult(
-          /^https?:\/\/.+\.(mp3|wav|ogg|m4a)$/i.test(content),
+          /^https?:\/\/.+$/i.test(content),
           et('invalidAudioUrl')
         );
       },


### PR DESCRIPTION
It turns out that some valid image / audio links without extensions won't pass our validation method. Then let's remove it completely.
